### PR TITLE
Fix HTML: Those spaces are a mandatory part of the comment syntax.

### DIFF
--- a/Docs/index.html
+++ b/Docs/index.html
@@ -1,5 +1,5 @@
 <html>
-    <!-----------------------------------------------------------------------------+
+    <!-- --------------------------------------------------------------------------+
      |  Extended Memory Semantics (EMS)                            Version 1.4.0   |
      |  Synthetic Semantics       http://www.synsem.com/       mogill@synsem.com   |
      +-----------------------------------------------------------------------------+
@@ -29,7 +29,7 @@
      |    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS       |
      |    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.             |
      |                                                                             |
-     +----------------------------------------------------------------------------->
+     +-------------------------------------------------------------------------- -->
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link rel="stylesheet" type="text/css" href="./docs.css">

--- a/Docs/reference.html
+++ b/Docs/reference.html
@@ -1,5 +1,5 @@
 <html>
-    <!-----------------------------------------------------------------------------+
+    <!-- --------------------------------------------------------------------------+
      |  Extended Memory Semantics (EMS)                            Version 0.2.0   |
      |  Synthetic Semantics       http://www.synsem.com/       mogill@synsem.com   |
      +-----------------------------------------------------------------------------+
@@ -28,7 +28,7 @@
      |    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS       |
      |    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.             |
      |                                                                             |
-     +----------------------------------------------------------------------------->
+     +-------------------------------------------------------------------------- -->
 
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
No idea why Github marks the other dashes as error. Afaik, even with a space before them they should not be relevant unless followed by `>`.